### PR TITLE
feat: improve offline mode and flashcards

### DIFF
--- a/coach.html
+++ b/coach.html
@@ -212,6 +212,7 @@
                 <button id="sessionBtn" class="btn">Gérer la Session</button>
                 <button id="loadSamplesBtn" class="btn" title="Charger des exemples de QCM et fiches">Charger Exemples</button>
                 <select id="aiProvider" class="input" aria-label="Fournisseur IA">
+                    <option value="offline" selected>Local (offline)</option>
                     <option value="internal">IA Interne (Rapide)</option>
                     <option value="openai">OpenAI</option>
                     <option value="firecrawl">Firecrawl (Local RAG)</option>

--- a/script.clean.js
+++ b/script.clean.js
@@ -10,7 +10,8 @@
   const esc = (s)=> String(s||'').replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]));
   const API_BASE = location.protocol.startsWith('http') ? location.origin : 'http://127.0.0.1:8000';
   const store = {
-    get provider(){ return localStorage.getItem('provider') || 'internal'; },
+    // Provider stored in localStorage; default to fully offline mode
+    get provider(){ return localStorage.getItem('provider') || 'offline'; },
     set provider(v){ try{ localStorage.setItem('provider', v); }catch{} },
     get apiKey(){ return localStorage.getItem('apiKey') || ''; },
     set apiKey(v){ try{ localStorage.setItem('apiKey', v); }catch{} },
@@ -34,10 +35,14 @@
   // --- Provider status ---
   async function updateProviderStatus(){
     const sel=$('#aiProvider'); const keyIn=$('#apiKey'); const badge=$('#providerStatus');
-    const provider=(sel&&sel.value)||store.provider||'internal'; const key=(keyIn&&keyIn.value)||store.apiKey||'';
+    const provider=(sel&&sel.value)||store.provider||'offline'; const key=(keyIn&&keyIn.value)||store.apiKey||'';
     store.provider=provider; if(keyIn) store.apiKey=keyIn.value;
     if(badge){ badge.textContent='Test…'; badge.style.background='transparent'; badge.style.border='1px solid var(--border-color, #334155)'; }
     try{
+      if(provider==='offline'){
+        if(badge){ badge.textContent='Local (offline)'; badge.className='badge success'; }
+        return;
+      }
       if(provider==='internal'){
         const h=await getHealth(); const ok=!!h; const ready=!!(h&&h.llm&&h.llm.ready===true);
         const def=(h&&h.llm&&h.llm.default_model)?` • modèle: ${h.llm.default_model}`:'';
@@ -380,14 +385,16 @@
     const themes = _segmentThemes(txt);
     function classify(text){ const t=String(text||'').toLowerCase(); if(/(règle|loi|si\s.+\salors|doit|il faut)/.test(t)) return 'RÈGLE'; if(/(définition|est appelé|on appelle|désigne)/.test(t)) return 'DÉFINITION'; if(/(théorème|propriété|proposition|lemme)/.test(t)) return 'THÉORÈME'; if(/(formule|≈|=|∑|\b\d+\s*%\b|\^|≤|≥|->)/.test(t)) return 'FORMULE'; if(/(attention|piège|exception|sauf|ne pas confondre)/.test(t)) return 'EXCEPTION'; return 'CONCEPT'; }
     const cards=[]; themes.forEach(t=>{ _splitSentences(t.body).slice(0,20).forEach(s=>{ const type=classify(s); let q=''; const head=_keywords(s,1)[0]||'ce concept'; if(type==='DÉFINITION') q=`Qu'est-ce que ${head} ?`; else if(type==='RÈGLE') q=`Quelle règle s'applique à ${head} ?`; else if(type==='FORMULE') q='Quelle est la formule utile ?'; else if(type==='THÉORÈME') q='Quel énoncé retenir ?'; else if(type==='EXCEPTION') q='Quelle exception faut-il connaître ?'; else q=`Point clé (${t.title}) ?`; cards.push({ theme:t.title, type, q, a:s }); }); });
+    cards.forEach((c,i)=>{ c.q = `Q${i+1}. ${c.q}`; });
     const byTheme={}; cards.forEach(c=>{ (byTheme[c.theme]=byTheme[c.theme]||[]).push(c); });
-    const filters = `<div class="sheet-toolbar"><div style="display:flex;gap:6px;flex-wrap:wrap"><strong>Filtres</strong><select id="fc-theme" class="input"><option value="">Tous les thèmes</option>${Object.keys(byTheme).map(t=>`<option>${esc(t)}</option>`).join('')}</select><select id="fc-type" class="input"><option value="">Tous les types</option>${['RÈGLE','DÉFINITION','FORMULE','THÉORÈME','EXCEPTION','CONCEPT'].map(t=>`<option>${t}</option>`).join('')}</select></div><div style="display:flex;gap:6px;flex-wrap:wrap"><button class="btn" id="fc-export">Exporter</button></div></div>`;
-    const grid = `<div id="flashcards-grid" class="sheet-grid">${cards.map(c=>`<div class="card fc" data-theme="${_slug(c.theme)}" data-type="${c.type}"><div class="q"><span class="badge">${c.type}</span> ${esc(c.q)}</div><details class="a"><summary>Voir la réponse</summary><p>${esc(c.a)}</p></details><small class="muted">${esc(c.theme)}</small></div>`).join('')}</div>`;
+    const filters = `<div class="fc-toolbar"><strong>Filtres</strong><select id="fc-theme" class="input"><option value="">Tous les thèmes</option>${Object.keys(byTheme).map(t=>`<option>${esc(t)}</option>`).join('')}</select><select id="fc-type" class="input"><option value="">Tous les types</option>${['RÈGLE','DÉFINITION','FORMULE','THÉORÈME','EXCEPTION','CONCEPT'].map(t=>`<option>${t}</option>`).join('')}</select><button class="btn" id="fc-export">Exporter</button></div>`;
+    const grid = `<div id="flashcards-grid" class="fc-deck">${cards.map(c=>`<div class="flashcard" data-theme="${_slug(c.theme)}" data-type="${c.type}"><div class="fc-inner"><div class="fc-face fc-front"><span class="badge">${c.type}</span> ${esc(c.q)}</div><div class="fc-face fc-back">${esc(c.a)}</div></div><small class="muted">${esc(c.theme)}</small></div>`).join('')}</div>`;
     out.innerHTML = filters + grid;
+    Array.from(out.querySelectorAll('.fc-inner')).forEach(inner=>inner.addEventListener('click',()=>inner.classList.toggle('flip')));
     const themeSel = document.getElementById('fc-theme'); const typeSel=document.getElementById('fc-type');
-    function applyFilters(){ const t=themeSel && themeSel.value || ''; const ty=typeSel && typeSel.value || ''; Array.from(document.querySelectorAll('#flashcards-grid .fc')).forEach(card=>{ const okT = !t || card.getAttribute('data-theme')===_slug(t); const okTy=!ty || card.getAttribute('data-type')===ty; card.style.display = (okT && okTy)? '' : 'none'; }); }
+    function applyFilters(){ const t=themeSel && themeSel.value || ''; const ty=typeSel && typeSel.value || ''; Array.from(document.querySelectorAll('#flashcards-grid .flashcard')).forEach(card=>{ const okT = !t || card.getAttribute('data-theme')===_slug(t); const okTy=!ty || card.getAttribute('data-type')===ty; card.style.display = (okT && okTy)? '' : 'none'; }); }
     themeSel && themeSel.addEventListener('change', applyFilters); typeSel && typeSel.addEventListener('change', applyFilters);
-    const exportBtn = document.getElementById('fc-export'); exportBtn && exportBtn.addEventListener('click', ()=>{ const visible = Array.from(document.querySelectorAll('#flashcards-grid .fc')).filter(c=>c.style.display!== 'none'); const txt = visible.map(c=>`# ${c.getAttribute('data-type')}\nQ: ${c.querySelector('.q')?.innerText||''}\nA: ${c.querySelector('.a')?.innerText||''}\n`).join('\n'); const blob=new Blob([txt],{type:'text/plain'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='flashcards.txt'; a.click(); URL.revokeObjectURL(url); });
+    const exportBtn = document.getElementById('fc-export'); exportBtn && exportBtn.addEventListener('click', ()=>{ const visible = Array.from(document.querySelectorAll('#flashcards-grid .flashcard')).filter(c=>c.style.display!== 'none'); const txt = visible.map(c=>`# ${c.getAttribute('data-type')}\nQ: ${c.querySelector('.fc-front')?.innerText||''}\nA: ${c.querySelector('.fc-back')?.innerText||''}\n`).join('\n'); const blob=new Blob([txt],{type:'text/plain'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='flashcards.txt'; a.click(); URL.revokeObjectURL(url); });
   }
   async function updateSRS(txt, data){
     const out = document.getElementById('srs-output'); if(!out) return;
@@ -529,6 +536,7 @@
     try{ const html=document.documentElement; let saved=localStorage.getItem('selected-theme')||'theme-nour'; if(saved==='theme-light') saved='theme-nour'; html.classList.remove('theme-nour','theme-light','theme-studycave'); html.classList.add(saved); html.classList.add('theme-dark'); const sel=$('#theme-select'); if(sel){ sel.value=saved; on(sel,'change',e=>{ const v=e.target.value; html.classList.remove('theme-nour','theme-light','theme-studycave'); html.classList.add(v); html.classList.add('theme-dark'); localStorage.setItem('selected-theme', v); }); } }catch{}
     // Provider controls
     const prov=$('#aiProvider'); const key=$('#apiKey'); if(prov){ prov.value=store.provider; on(prov,'change', updateProviderStatus); } if(key){ key.value=store.apiKey; on(key,'change', updateProviderStatus); on(key,'input',()=>{ store.apiKey=key.value; updateProviderStatus(); }); }
+    document.addEventListener('keydown',e=>{ if((e.metaKey||e.ctrlKey)&&e.key.toLowerCase()==='o'){ if(prov) prov.value='offline'; store.provider='offline'; updateProviderStatus(); } if((e.metaKey||e.ctrlKey)&&e.key.toLowerCase()==='i'){ if(prov) prov.value='internal'; store.provider='internal'; updateProviderStatus(); } });
     updateProviderStatus();
     // Tabs
     wireTabs();

--- a/style.css
+++ b/style.css
@@ -680,16 +680,13 @@ textarea {
   font-size: 1.1rem;
   line-height: 1.5;
 }
-.fc-toolbar{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:10px}
-.fc-deck{position:relative;display:grid;place-items:center;min-height:260px;padding:12px;perspective:1000px}
-.fc-card{position:relative;width:min(640px,100%);min-height:240px;border-radius:16px;border:1px solid var(--border-color);background:var(--surface-color);box-shadow:var(--shadow-md);transform-style:preserve-3d;transition:transform .6s ease, box-shadow .2s ease;will-change:transform}
-.fc-card:hover{box-shadow:0 16px 40px rgba(20,30,58,.18)}
-.fc-card.is-flipped{transform:rotateY(180deg)}
-.fc-card .face{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;padding:24px 20px;backface-visibility:hidden;border-radius:16px;overflow:auto}
-.fc-card .face.front{transform:rotateY(0deg)}
-.fc-card .face.back{transform:rotateY(180deg)}
-.fc-card .face h3{margin:0;font-size:1.2rem}
-.fc-card .face p{margin:0;font-size:1rem;line-height:1.6}
+.fc-toolbar{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; justify-content:center; }
+.fc-deck{ display:flex; flex-direction:column; gap:10px; align-items:center; }
+.flashcard{ width:min(720px,96%); height:280px; perspective:1200px; position:relative; }
+.fc-inner{ position:absolute; inset:0; border:1px solid var(--border-color); border-radius:14px; background:var(--surface-2); display:flex; align-items:center; justify-content:center; padding:18px; text-align:center; font-size:1.05rem; transform-style:preserve-3d; transition:transform .5s ease; }
+.fc-inner.flip{ transform: rotateY(180deg); }
+.fc-face{ position:absolute; inset:0; backface-visibility:hidden; display:flex; align-items:center; justify-content:center; padding:20px; text-align:center; line-height:1.5; }
+.fc-back{ transform: rotateY(180deg); }
 
 .fc-actions{display:flex;gap:10px;justify-content:center;margin-top:12px;flex-wrap:wrap}
 


### PR DESCRIPTION
## Summary
- default to offline mode and show status badge without network calls
- add keyboard shortcuts for toggling offline or internal providers
- prefix flashcard questions and render flip-style deck with new CSS

## Testing
- `pytest` *(fails: No module named 'server')*

------
https://chatgpt.com/codex/tasks/task_e_68a275f573488323b777505dddc05a3f