### PR TITLE
Add offline course summarization

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ def _norm(s: str) -> str:
 def extract(inp: ExtractIn):
     text = (inp.text or inp.content or "").strip()
     if not text:
-        return {"data": {"notions_cles": [], "definitions": [], "questions": []}}
+        return {"data": {"notions_cles": [], "definitions": [], "questions": [], "resume": ""}}
 
     tokens = re.findall(r"[A-Za-zÀ-ÿ]{3,}", text)
     stop = set("le la les de des du un une et ou a au aux en dans pour par avec sans sur sous entre d l que qui quoi dont est sont ete été etre être ce cet cette ces il elle nous vous on ne pas".split())
@@ -45,5 +45,14 @@ def extract(inp: ExtractIn):
             if len(defs) >= 8:
                 break
 
+    sentences = re.split(r"(?<=[\.!?…])\s+", text)
+    scores = []
+    for i, s in enumerate(sentences):
+        words = [_norm(t) for t in re.findall(r"[A-Za-zÀ-ÿ]{3,}", s)]
+        score = sum(cnt[w] for w in words)
+        scores.append((i, score, s.strip()))
+    top = sorted(scores, key=lambda x: x[1], reverse=True)[:3]
+    resume = " ".join([s for i,_,s in sorted(top, key=lambda x: x[0])])
+
     questions = [f"Expliquez la notion: « {w} »." for w in notions[:6]]
-    return {"data": {"notions_cles": notions, "definitions": defs, "questions": questions}}
+    return {"data": {"notions_cles": notions, "definitions": defs, "questions": questions, "resume": resume}}

--- a/server/app.py
+++ b/server/app.py
@@ -219,7 +219,7 @@ def _norm(s: str) -> str:
 def extract(inp: ExtractIn):
     text = (inp.text or inp.content or "").strip()
     if not text:
-        return {"data": {"notions_cles": [], "definitions": [], "questions": []}}
+        return {"data": {"notions_cles": [], "definitions": [], "questions": [], "resume": ""}}
 
     tokens = re.findall(r"[A-Za-zÀ-ÿ]{3,}", text)
     stop = set("le la les de des du un une et ou a au aux en dans pour par avec sans sur sous entre d l que qui quoi dont est sont ete été etre être ce cet cette ces il elle nous vous on ne pas".split())
@@ -235,8 +235,17 @@ def extract(inp: ExtractIn):
             if len(defs) >= 8:
                 break
 
+    sentences = re.split(r"(?<=[\.!?…])\s+", text)
+    scores = []
+    for i, s in enumerate(sentences):
+        words = [_norm(t) for t in re.findall(r"[A-Za-zÀ-ÿ]{3,}", s)]
+        score = sum(cnt[w] for w in words)
+        scores.append((i, score, s.strip()))
+    top = sorted(scores, key=lambda x: x[1], reverse=True)[:3]
+    resume = " ".join([s for i,_,s in sorted(top, key=lambda x: x[0])])
+
     questions = [f"Expliquez la notion: « {w} »." for w in notions[:6]]
-    return {"data": {"notions_cles": notions, "definitions": defs, "questions": questions}}
+    return {"data": {"notions_cles": notions, "definitions": defs, "questions": questions, "resume": resume}}
 
 # === Validation utilities (JSON schema) ===
 from jsonschema import validate as _validate, ValidationError

--- a/tests/test_llm_endpoints.py
+++ b/tests/test_llm_endpoints.py
@@ -33,3 +33,10 @@ def test_validate_sheet_schema():
     }
     r = client.post('/validate/sheet', json=payload)
     assert r.status_code == 200 and r.json().get('ok') is True
+
+
+def test_extract_summary():
+    body = {"text": "La révolution française commence en 1789. Elle change profondément la société. Les idées de liberté se diffusent."}
+    r = client.post('/v1/extract', json=body)
+    data = r.json().get('data', {})
+    assert r.status_code == 200 and data.get('resume')


### PR DESCRIPTION
## Summary
- enhance extract endpoint to generate a short summary from supplied text
- surface summary in API responses for better offline understanding
- add regression test for the new summary field

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3569598e48323b10c1ec766fa2fa0