### PR TITLE
Fix flashcard interactions and dark theme styling

### DIFF
--- a/script.clean.js
+++ b/script.clean.js
@@ -308,19 +308,26 @@ function ensureFlashcardsPane(){
   return pane;
 }
 function renderFlashcards(){
-  const host = ensureFlashcardsPane();
-  host.innerHTML=CM.qa.flashcards.map((fc,i)=>`
+  const host = document.getElementById('flashcards-pane');
+  if(!host) return;
+  host.innerHTML = CM.qa.flashcards.map((fc,i)=>`
     <div class="flashcard" data-i="${i}">
-      <div class="flashcard-front">${fc.q}</div>
-      <div class="flashcard-back hidden">${fc.a}</div>
-      <button class="flip">Retourner</button>
+      <div class="flashcard-inner">
+        <div class="flashcard-front">${fc.q}</div>
+        <div class="flashcard-back hidden">${fc.a}</div>
+      </div>
+      <button class="flip-btn">↺ Retourner</button>
     </div>
   `).join('');
   host.querySelectorAll('.flashcard').forEach(card=>{
-    const front=card.querySelector('.flashcard-front');
-    const back=card.querySelector('.flashcard-back');
-    card.querySelector('.flip').addEventListener('click',()=>{
-      front.classList.toggle('hidden'); back.classList.toggle('hidden');
+    const inner = card.querySelector('.flashcard-inner');
+    const front = card.querySelector('.flashcard-front');
+    const back = card.querySelector('.flashcard-back');
+    const flipBtn = card.querySelector('.flip-btn');
+    flipBtn.addEventListener('click',()=>{
+      inner.classList.toggle('flipped');
+      front.classList.toggle('hidden');
+      back.classList.toggle('hidden');
     });
   });
 }
@@ -378,10 +385,14 @@ async function runUnifiedPipeline(text, mode='offline', setStatus=(s)=>{}){
   // Ouvre/ferme le modal
   function wireSettings(){
     ensureSettingsModal();
-    const btn = $('#settingsBtn') || $('[data-role="settings"]') || $('#gearBtn');
+    // Cherche plus large si bouton absent
+    const btn = document.querySelector('#settingsBtn, [data-role="settings"], #gearBtn, .settings-btn');
     if(!btn) return;
     if(btn.dataset.bound) return; btn.dataset.bound='1';
-    btn.addEventListener('click', (e)=>{ e.preventDefault(); $('#settingsModal').classList.add('open'); });
+    btn.addEventListener('click', (e)=>{
+      e.preventDefault();
+      document.getElementById('settingsModal').classList.add('open');
+    });
   }
 
   // Déverrouille les onglets quand des données existent

--- a/style.css
+++ b/style.css
@@ -1124,3 +1124,14 @@ textarea::placeholder, input::placeholder{ color:var(--muted) !important; }
 #settingsModal.open{ display:flex; }
 #settingsModal .modal-card{ width:min(560px,92vw); background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:16px; box-shadow:0 20px 60px rgba(0,0,0,.5); }
 #settingsModal .modal-card h3{ margin:.25rem 0 1rem; color:var(--accent); }
+
+/* Fix visibilité fiches & cartes */
+.fiche, .fiche-card, .qcm-item, .flashcard {
+  background: var(--panel) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border) !important;
+}
+
+.fiche h4, .fiche h5, .flashcard-front, .flashcard-back {
+  color: var(--text) !important;
+}


### PR DESCRIPTION
## Summary
- Align flashcard markup with CSS and restore flip interactions
- Broaden settings button selector for more robust binding
- Enforce dark theme colors on fiches, QCM items and flashcards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36b5636d48323ba6d24f479ea71ae